### PR TITLE
add NULL as pythonBuiltin and fix miscellaneous links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # vim-cython-syntax
 
-A vim syntax plugin for [Cython][] based on Vim's [Python syntax file](https://github.com/vim/vim/blob/master/runtime/syntax/python.vim).
+A vim syntax plugin for [Cython](https://cython.org/) based on Vim's [Python
+syntax file](https://github.com/vim/vim/blob/master/runtime/syntax/python.vim).

--- a/ftdetect/cython.vim
+++ b/ftdetect/cython.vim
@@ -6,7 +6,7 @@ function! s:overwrite_filetype() abort
 endfunction
 
 " Cython
-" http://docs.cython.org/src/reference/language_basics.html
+" https://docs.cython.org/src/userguide/language_basics.html
 autocmd BufNewFile,BufRead *.pyx call s:overwrite_filetype()  " Implementation file
 autocmd BufNewFile,BufRead *.pxd call s:overwrite_filetype()  " Definition file
 autocmd BufNewFile,BufRead *.pxi call s:overwrite_filetype()  " Include files

--- a/syntax/cython.vim
+++ b/syntax/cython.vim
@@ -19,6 +19,7 @@ syntax keyword cythonType const signed unsigned
 syntax keyword cythonType char short int long bint
 syntax keyword cythonType float double
 syntax keyword cythonType void object
+syntax keyword cythonNull NULL
 
 " While Cython use 'from' in import/cimport, cdef-extern, and for-loop, it
 " could not be listed in 'pythonInclude' syntax as a keyword.
@@ -87,6 +88,7 @@ highlight default link cythonAccessor       cythonStatement
 highlight default link cythonFunction       pythonFunction
 highlight default link cythonDefine         Macro
 highlight default link cythonBuiltin        pythonBuiltin
+highlight default link cythonNull           pythonBuiltin
 
 highlight default link cythonDirective      pythonComment
 highlight default link cythonDirectiveTerms Define


### PR DESCRIPTION
This commit adds support for C's [NULL](https://en.cppreference.com/w/cpp/types/NULL). According to the Cython [documentation](https://cython.readthedocs.io/en/latest/src/userguide/language_basics.html#differences-between-c-and-cython-expressions):
> "The null C pointer is called `NULL`, not `0`. `NULL` is a reserved word in Cython and special object in pure python mode."

meaning that `NULL` is a keyword in Cython and is `cython.NULL` in pure Python mode. Because `NULL` is a built-in keyword that can be used without importing anything, I think it should be highlighted as `pythonBuiltin` in the default vim Python syntax. This matches the behavior of `None`, which is Python's closest construct to `NULL`, since `None` is a [pythonBuiltin](https://github.com/vim/vim/blob/68e64d2c1735f2a39afa8a0475ae29bedb116684/runtime/syntax/python.vim#L192).

In addition to this change, the broken URL in [ftdetect/cython.vim](https://github.com/lambdalisue/vim-cython-syntax/compare/master...stephen-huan:master#diff-e9549abde2cb43efbe68dda65b86aa38a44617dcfc8f2edffd992c1bdab27ca3) has been updated to the current language basics section and the broken link in [README.md](https://github.com/lambdalisue/vim-cython-syntax/compare/master...stephen-huan:master#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) has been changed to the Cython homepage.